### PR TITLE
add Set (as an extension of List) to Container; tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Type
  |           |
 Scalar      Container
  |           |
- |           +------+
- |           |      |
- |          List   Map
+ |           +------+------+
+ |           |      |      |
+ |          List   Map    Set
  |
  +-----+------+------+
  |     |      |      |
@@ -48,6 +48,8 @@ Containers have multiple children.
 List represents an array.
 
 Map represents an object.
+
+Set represents a set.
 
 
 ## Schema

--- a/packages/conformist-schema/src/index.js
+++ b/packages/conformist-schema/src/index.js
@@ -311,6 +311,14 @@ class List extends Container {
 
 List.prototype.members = [];
 
+@staticify
+class Set extends List {
+  get value() {
+    return Immutable.Set(this.members.map(m => m.value));
+  }
+}
+
+Set.prototype.members = [];
 
 @staticify
 class Map extends Container {
@@ -421,4 +429,4 @@ class Map extends Container {
 }
 
 
-export default {Type, Scalar, Num, Int, Str, Bool, Enum, Container, List, Map};
+export default {Type, Scalar, Num, Int, Str, Bool, Enum, Container, List, Set, Map};

--- a/packages/conformist-schema/test.js
+++ b/packages/conformist-schema/test.js
@@ -6,7 +6,7 @@ import sinon from 'sinon';
 import Immutable from 'immutable';
 
 import Schema from './src/index';
-let {Int, Str, Bool, Enum, Map, List} = Schema;
+let {Int, Str, Bool, Enum, Map, List, Set} = Schema;
 
 
 describe('Type', () => {
@@ -100,6 +100,26 @@ describe('Type', () => {
   })
 
   describe('Containers', () => {
+    describe('Set', () => {
+      var Ints = Set.of(Int);
+      it('should "set" a valid Set', () => {
+        let ints = new Ints;
+        ints.set([1, 2, 2, 3]);
+        expect(ints.value).to.equal(Immutable.Set([1, 2, 3]));
+      })
+
+      it('should "set" defaults', () => {
+        var DefaultedInts = Ints.using({default: [1, 2, 3, 3]});
+        let dints = new DefaultedInts;
+        expect(dints.value).to.equal(Immutable.Set([]));
+        // on an instance
+        dints.setDefault();
+        expect(dints.value).to.equal(Immutable.Set(dints.default));
+        // on a class
+        let ddints = DefaultedInts.fromDefaults();
+        expect(ddints.value).to.equal(Immutable.Set(ddints.default));
+      })
+    })
 
     describe('List', () => {
       var Strings = List.of(Str);


### PR DESCRIPTION
I added what I thought would be a good approach to adding Sets to the `Container` type by inheriting the List container type. Does this make sense? What is the implication if the `set(raw)` function is called?

Also not sure if it's time/place to add this, as I anticipate your merge of `feature/packages` to `master` as imminent.
